### PR TITLE
Custom parse_dates option on CSVLoader

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,5 @@ channels:
 dependencies:
   - python=3.10
   - pip
-  - hdf5  # this will install the HDF5 binaries required by pytables (even on a Mac)
+  - hdf5 # this will install the HDF5 binaries required by pytables (even on a Mac)
+  - jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ tables = "^3.9.2"
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4.2"
 bump-my-version = "^0.20.0"
+pandas-stubs = "^2.2.1.240316"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/workflowlib/_typing.py
+++ b/src/workflowlib/_typing.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+from os import PathLike
+from typing import (
+    Any,
+    Iterator,
+    Protocol,
+    Sequence,
+    SupportsIndex,
+    TypeVar,
+    Union,
+    overload,
+)
+
+# list-like
+
+# from https://github.com/hauntsaninja/useful_types
+# includes Sequence-like objects but excludes str and bytes
+_T_co = TypeVar("_T_co", covariant=True)
+
+
+class SequenceNotStr(Protocol[_T_co]):
+    @overload
+    def __getitem__(self, index: SupportsIndex, /) -> _T_co: ...
+
+    @overload
+    def __getitem__(self, index: slice, /) -> Sequence[_T_co]: ...
+
+    def __contains__(self, value: object, /) -> bool: ...
+
+    def __len__(self) -> int: ...
+
+    def __iter__(self) -> Iterator[_T_co]: ...
+
+    def index(self, value: Any, /, start: int = 0, stop: int = ...) -> int: ...
+
+    def count(self, value: Any, /) -> int: ...
+
+    def __reversed__(self) -> Iterator[_T_co]: ...
+
+
+ListLike = Union[SequenceNotStr, range]
+
+
+# filenames and file-like-objects
+AnyStr_co = TypeVar("AnyStr_co", str, bytes, covariant=True)
+AnyStr_contra = TypeVar("AnyStr_contra", str, bytes, contravariant=True)
+
+
+class BaseBuffer(Protocol):
+    @property
+    def mode(self) -> str:
+        # for _get_filepath_or_buffer
+        ...
+
+    def seek(self, __offset: int, __whence: int = ...) -> int:
+        # with one argument: gzip.GzipFile, bz2.BZ2File
+        # with two arguments: zip.ZipFile, read_sas
+        ...
+
+    def seekable(self) -> bool:
+        # for bz2.BZ2File
+        ...
+
+    def tell(self) -> int:
+        # for zip.ZipFile, read_stata, to_stata
+        ...
+
+
+class ReadBuffer(BaseBuffer, Protocol[AnyStr_co]):
+    def read(self, __n: int = ...) -> AnyStr_co:
+        # for BytesIOWrapper, gzip.GzipFile, bz2.BZ2File
+        ...
+
+
+class WriteBuffer(BaseBuffer, Protocol[AnyStr_contra]):
+    def write(self, __b: AnyStr_contra) -> Any:
+        # for gzip.GzipFile, bz2.BZ2File
+        ...
+
+    def flush(self) -> Any:
+        # for gzip.GzipFile, bz2.BZ2File
+        ...
+
+
+class ReadCsvBuffer(ReadBuffer[AnyStr_co], Protocol):
+    def __iter__(self) -> Iterator[AnyStr_co]:
+        # for engine=python
+        ...
+
+    def fileno(self) -> int:
+        # for _MMapWrapper
+        ...
+
+    def readline(self) -> AnyStr_co:
+        # for engine=python
+        ...
+
+    @property
+    def closed(self) -> bool:
+        # for enine=pyarrow
+        ...
+
+
+FilePath = Union[str, os.PathLike]

--- a/src/workflowlib/base.py
+++ b/src/workflowlib/base.py
@@ -1,3 +1,5 @@
+import io
+import os
 from pathlib import Path
 from typing import Any, Optional
 
@@ -26,7 +28,7 @@ class ProcessStepBase(pydantic.BaseModel):
 
 class Loader(ProcessStepBase):
     @staticmethod
-    def get_sources(source: str | Path):
+    def glob(source: str | os.PathLike):
         path = Path(source)
 
         path = path.absolute()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -11,7 +11,7 @@ class TestLoader:
         )
 
         sources = list(
-            loader.get_sources(
+            loader.glob(
                 source=data_path / 'eurotherm/20240118T084901.txt',
             )
         )
@@ -24,7 +24,7 @@ class TestLoader:
         )
 
         sources = list(
-            loader.get_sources(
+            loader.glob(
                 source=data_path / 'eurotherm/*.txt',
             )
         )
@@ -45,7 +45,7 @@ class TestLoader:
         )
 
         sources = list(
-            loader.get_sources(
+            loader.glob(
                 source=data_path / 'eurotherm/subfolder/**/*.txt',
             )
         )


### PR DESCRIPTION
Parsing nested columns with the parse_dates option when loading files with pandas.read_csv is deprecated since Pandas v2.2. To avoid future warnings, a custom implementation for joining columns and parsing dates has been implemented.