### PR TITLE
style: Renamed "select.[columns|timespan]" to "dataframe.select.[columns|timespan]"

### DIFF
--- a/src/workflowlib/dataframes/selection.py
+++ b/src/workflowlib/dataframes/selection.py
@@ -7,7 +7,7 @@ from ..process import Transform
 
 
 class SelectColumns(Transform):
-    name: str = 'select.columns'
+    name: str = 'dataframe.select.columns'
     version: str = '1'
 
     def run(
@@ -26,7 +26,7 @@ class SelectColumns(Transform):
 
 
 class SelectTimespan(Transform):
-    name: str = 'select.timespan'
+    name: str = 'dataframe.select.timespan'
     version: str = '1'
 
     def run(self, source: pd.DataFrame, column: str, start=None, stop=None):

--- a/tests/dataframes/test_selection.py
+++ b/tests/dataframes/test_selection.py
@@ -11,7 +11,7 @@ class TestSelectColumns:
     def test_create_loader(self):
         transform = SelectColumns()
 
-        assert transform.name == 'select.columns'
+        assert transform.name == 'dataframe.select.columns'
         assert transform.version == '1'
 
     def test_select_single(self, data_path: Path):
@@ -70,7 +70,7 @@ class TestSelectTimespan:
     def test_create_loader(self):
         loader = SelectTimespan()
 
-        assert loader.name == 'select.timespan'
+        assert loader.name == 'dataframe.select.timespan'
         assert loader.version == '1'
 
     def test_process(self, data_path: Path):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -25,7 +25,7 @@ def test_run_sequence(data_path):
             },
         },
         {
-            'run': 'select.columns@v1',
+            'run': 'dataframe.select.columns@v1',
             'params': {
                 'select': {
                     "timestamp": "timestamp",
@@ -67,7 +67,7 @@ class TestWorkflow:
                 },
             },
             {
-                'run': 'select.timespan@v1',
+                'run': 'dataframe.select.timespan@v1',
                 'params': {
                     'column': 'timestamp',
                     'start': '2024-01-16T10:05:22.5',
@@ -75,7 +75,7 @@ class TestWorkflow:
                 },
             },
             {
-                'run': 'select.columns@v1',
+                'run': 'dataframe.select.columns@v1',
                 'params': {
                     'select': {
                         "timestamp": "timestamp",
@@ -109,7 +109,7 @@ class TestWorkflow:
                 },
             },
             {
-                'run': 'select.columns@v1',
+                'run': 'dataframe.select.columns@v1',
                 'params': {
                     'select': {
                         "timestamp": "timestamp",
@@ -143,7 +143,7 @@ class TestWorkflow:
                             },
                         },
                         {
-                            'run': 'select.columns@v1',
+                            'run': 'dataframe.select.columns@v1',
                             'params': {
                                 'select': {
                                     "timestamp": "timestamp",


### PR DESCRIPTION
This makes the naming scheme of processes working on pandas data frames consistent to each other.

BREAKING CHANGE: Processes that use the old names will break.